### PR TITLE
修改renderExtra的渲染位置在箭头左侧

### DIFF
--- a/packages/vantui/src/cell/index.tsx
+++ b/packages/vantui/src/cell/index.tsx
@@ -87,6 +87,7 @@ export function Cell(props: CellProps) {
       <View className="van-cell__value value-class">
         {value || value === 0 ? <>{value}</> : children}
       </View>
+      <View>{renderExtra}</View>
       <View>
         {isLink ? (
           <Icon
@@ -97,7 +98,6 @@ export function Cell(props: CellProps) {
           renderRightIcon
         )}
       </View>
-      <View>{renderExtra}</View>
     </View>
   )
 }


### PR DESCRIPTION
renderExtra 现在是在箭头的右侧，这个在实际使用的时候会有问题，比如：
![image](https://github.com/chj-damon/vantui/assets/4902684/ba2d2a21-42cd-48d8-95b9-41ea8591fa73)
应该保持箭头在最右边。

另外，value目前的类型是string | number, 无法支持传入ReactNode

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 main 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] 快手小程序
- [x] QQ 轻应用
- [x] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**
